### PR TITLE
Fixing the `Toiletpaper.calculate_price` to match `Fruit.calculate_price`

### DIFF
--- a/Week 05/SLU09 - OOP Basics/utils.py
+++ b/Week 05/SLU09 - OOP Basics/utils.py
@@ -79,7 +79,7 @@ class Toiletpaper:
         self.days_until_expired = days_until_expired
 
     def calculate_price(self):
-        return self.price_per_unit
+        return self.nr_units * self.price_per_unit
 
 
 class Capturing(list):


### PR DESCRIPTION
Ultra small PR to address this ^
Also because having it return `price_per_unit` doesn't really make sense in an object that has the `nr_units` attribute.